### PR TITLE
Remove white color from top menu's icons

### DIFF
--- a/config/_default/menus.en.yaml
+++ b/config/_default/menus.en.yaml
@@ -16,7 +16,6 @@ main:
       icon:
         vendor: font-awesome-solid
         name: shop
-        color: white
 
   - name: AliExpress
     parent: stores
@@ -89,7 +88,6 @@ main:
       icon:
         vendor: font-awesome-solid
         name: info
-        color: white
 
   - name: Authors
     parent: info


### PR DESCRIPTION
White color make top menu's icons become invisible in light mode, it's recommend to not set the color.